### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "i": "^0.3.6",
     "native-base": "latest",
-    "npm": "^6.9.0",
     "react": "16.8.3",
     "react-native": "0.59.9",
     "react-native-elements": "latest",


### PR DESCRIPTION

Hello TarunReddy099!

It seems like you have npm as one of your (dev-) dependency in NECTAR-APP.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
